### PR TITLE
Editing a deleted message would cause an error

### DIFF
--- a/discord-bot.pluto
+++ b/discord-bot.pluto
@@ -69,6 +69,7 @@ class DiscordMessage
 	end
 
 	function reply(content)
+		if not self.id then return end
 		local data = self.client:sendRequest("POST", $"/channels/{self.channel.id}/messages", {
 			["content"] = content,
 			["message_reference"] = {
@@ -82,12 +83,14 @@ class DiscordMessage
 	end
 
 	function edit(content)
+		if not self.id then return end
 		self.client:sendRequest("PATCH", $"/channels/{self.channel.id}/messages/{self.id}", {
 			["content"] = content
 		})
 	end
 
 	function delete()
+		if not self.id then return end
 		self.client:sendRequest("DELETE", $"/channels/{self.channel.id}/messages/{self.id}")
 	end
 end


### PR DESCRIPTION
this check seemingly prevents it trying to edit the message if it no longer exists.

also added it to reply() and delete(), not sure if these are affected the same way as edit but i imagine if someone was able to delete the message before the bot could get to it, i imagine it would error in both of these functions

```pluto: ./discord-bot.pluto:85: attempt to concatenate a nil value (field 'id')
stack traceback:
        [C]: in function 'coroutine.xresume'
        [string "pluto:scheduler"]:14: in function 'scheduler.internalresume'
        [string "pluto:scheduler"]:52: in function 'scheduler.run'
        ./discord-bot.pluto:276: in function 'discord-bot.run'
        main.pluto:223: in main chunk
        [C]: in ?```